### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -7,6 +7,9 @@ jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - run: npm ci && npm run build


### PR DESCRIPTION
Potential fix for [https://github.com/bgebelein/better-weather-app/security/code-scanning/4](https://github.com/bgebelein/better-weather-app/security/code-scanning/4)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the `build_and_preview` job, giving the `GITHUB_TOKEN` only the minimal required scopes. For a Firebase Hosting deploy preview triggered by pull requests, the action typically needs to read repository contents and interact with pull requests (e.g., to comment with preview URLs), but it does not need broad write access to code, workflows, or other resources.

The best fix with minimal behavioral change is to add a `permissions` block at the job level under `build_and_preview`, specifying `contents: read` and `pull-requests: write`. This follows GitHub’s recommended minimal template from the CodeQL message while still allowing the action to read the code and write PR comments or statuses if it does so. No imports or other code changes are required; only the YAML configuration in `.github/workflows/firebase-hosting-pull-request.yml` is updated.

Concretely, in `.github/workflows/firebase-hosting-pull-request.yml`, under `jobs:`, inside the `build_and_preview:` job definition and at the same indentation level as `runs-on:`, insert:

```yaml
    permissions:
      contents: read
      pull-requests: write
```

This limits the `GITHUB_TOKEN` permissions only for this job, leaving other workflows unaffected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
