### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -8,6 +8,8 @@ name: Deploy to Firebase Hosting on merge
       - main
 jobs:
   build_and_deploy:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/bgebelein/better-weather-app/security/code-scanning/3](https://github.com/bgebelein/better-weather-app/security/code-scanning/3)

In general, the fix is to explicitly define `permissions` for the workflow or for the specific job, restricting the `GITHUB_TOKEN` to the least privileges required. Since this workflow only needs to check out code and run a Firebase hosting deploy, it typically requires only `contents: read` for the token. No other scopes (like `pull-requests`, `issues`, etc.) are used here.

The best minimal fix without changing existing functionality is to add a `permissions` block at the job level under `build_and_deploy` (the location CodeQL pointed to), specifying `contents: read`. This ensures that `GITHUB_TOKEN` used as `repoToken` is limited to read-only repository contents for this job, regardless of repo/org defaults. Concretely, in `.github/workflows/firebase-hosting-merge.yml`, under `jobs: build_and_deploy:`, insert:

```yaml
    permissions:
      contents: read
```

between `build_and_deploy:` and `runs-on: ubuntu-latest`. No imports or additional methods are needed since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
